### PR TITLE
add extern/json/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ extern/aabbcc/
 extern/geogram/
 extern/libigl/
 extern/nlopt/
+extern/json/


### PR DESCRIPTION
The directory extern/json/ is automatically generated, but it was not added to the .gitignore before